### PR TITLE
feat: add Philippines PhilGEPS dataset entry

### DIFF
--- a/dataset/philippines_philgeps.yaml
+++ b/dataset/philippines_philgeps.yaml
@@ -1,0 +1,5 @@
+country: 'ph'
+license_title: ''
+url: 'https://huggingface.co/datasets/bettergovph/philgeps-data/blob/main/oc4ids.json'
+portal_title: 'BetterGov Open Data Portal'
+portal_url: 'https://data.bettergov.ph'


### PR DESCRIPTION
This adds the Philippines' Philgeps dataset (Philippine Government Electronic Procurement System)

Data can be browsed at https://transparency.bettergov.ph and can be downloaded through our Open Data Portal https://data.bettergov.ph